### PR TITLE
restore dockercoins throttling behavior

### DIFF
--- a/rng/rng.csproj
+++ b/rng/rng.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <ThreadPoolMaxThreads>1</ThreadPoolMaxThreads>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Necessary to see the performance nonlinearity when scaling to 10 workers. Introducing a delay isn't enough, since that delay is async and per thread; .net will just start spinning up more threads to handle load if you don't throttle it.